### PR TITLE
[2/3] Add Models & Controllers for Survey Conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ node_modules
 # Ignore build for client
 /client/build
 .DS_Store
+
+# Ignore local node version
+.node-version

--- a/app/controllers/course/achievement/condition/surveys_controller.rb
+++ b/app/controllers/course/achievement/condition/surveys_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Course::Achievement::Condition::SurveysController < Course::Condition::SurveysController
+  include Course::AchievementConditionalConcern
+end

--- a/app/controllers/course/assessment/condition/surveys_controller.rb
+++ b/app/controllers/course/assessment/condition/surveys_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class Course::Assessment::Condition::SurveysController < Course::Condition::SurveysController
+  include Course::AssessmentConditionalConcern
+end

--- a/app/controllers/course/condition/surveys_controller.rb
+++ b/app/controllers/course/condition/surveys_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+class Course::Condition::SurveysController < Course::ConditionsController
+  load_resource :survey_condition, class: Course::Condition::Survey.name, parent: false
+  before_action :set_course_and_conditional, only: [:new, :create]
+  authorize_resource :survey_condition, class: Course::Condition::Survey.name
+
+  def new
+  end
+
+  def create
+    if @survey_condition.save
+      redirect_to return_to_path, success: t('course.condition.surveys.create.success')
+    else
+      render 'new'
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @survey_condition.update(survey_condition_params)
+      redirect_to return_to_path, success: t('course.condition.surveys.update.success')
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if @survey_condition.destroy
+      redirect_to return_to_path, success: t('course.condition.surveys.destroy.success')
+    else
+      redirect_to return_to_path, danger: t('course.condition.surveys.destroy.error')
+    end
+  end
+
+  private
+
+  def survey_condition_params
+    params.require(:condition_survey).permit(:survey_id)
+  end
+
+  def set_course_and_conditional
+    @survey_condition.course = current_course
+    @survey_condition.conditional = @conditional
+  end
+
+  # Define survey component for the check whether the component is defined.
+  #
+  # @return [Course::SurveyComponent] The survey component.
+  # @return [nil] If component is disabled.
+  def component
+    current_component_host[:course_survey_component]
+  end
+end

--- a/app/helpers/course/condition/conditions_helper.rb
+++ b/app/helpers/course/condition/conditions_helper.rb
@@ -19,6 +19,7 @@ module Course::Condition::ConditionsHelper
       hash[Course::Condition::Achievement.name] = :course_achievements_component
       hash[Course::Condition::Assessment.name] = :course_assessments_component
       hash[Course::Condition::Level.name] = :course_levels_component
+      hash[Course::Condition::Survey.name] = :course_survey_component
     end
   end
 end

--- a/app/models/course/condition/survey.rb
+++ b/app/models/course/condition/survey.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+class Course::Condition::Survey < ApplicationRecord
+  acts_as_condition
+  include DuplicationStateTrackingConcern
+
+  # Trigger for evaluating the satisfiability of conditionals for a course user
+  Course::Survey::Response.after_save do |response|
+    Course::Condition::Survey.on_dependent_status_change(response)
+  end
+
+  validate :validate_survey_condition, if: :survey_id_changed?
+  validates :survey, presence: true
+  belongs_to :survey, class_name: Course::Survey.name, inverse_of: :survey_conditions
+
+  default_scope { includes(:survey) }
+
+  alias_method :dependent_object, :survey
+
+  def title
+    self.class.human_attribute_name('title.complete', survey_title: survey.title)
+  end
+
+  # Checks if the user has completed the required survey.
+  #
+  # @param [CourseUser] course_user The user that the survey condition is being checked on. The
+  #   user must respond to `surveys` and returns an ActiveRecord::Association that
+  #   contains all surveys the subject has obtained.
+  # @return [Boolean] true if the user has the required survey and false otherwise.
+  def satisfied_by?(course_user)
+    # Unpublished surveys are considered not satisfied.
+    return false unless survey.published?
+    submitted_response_by_user(course_user)
+  end
+
+  # Class that the condition depends on.
+  def self.dependent_class
+    Course::Survey.name
+  end
+
+  def self.on_dependent_status_change(response)
+    return unless response.saved_changes.key?(:submitted_at)
+    response.execute_after_commit { evaluate_conditional_for(response.course_user) }
+  end
+
+  def initialize_duplicate(duplicator, other)
+    self.survey = duplicator.duplicate(other.survey)
+    self.conditional_type = other.conditional_type
+    self.conditional = duplicator.duplicate(other.conditional)
+
+    if duplicator.mode == :course
+      self.course = duplicator.duplicate(other.course)
+    elsif duplicator.mode == :object
+      self.course = duplicator.options[:destination_course]
+    end
+
+    set_duplication_flag
+  end
+
+  private
+
+  def submitted_response_by_user(user)
+    survey.responses.submitted.find_by(course_user_id: user.id)
+  end
+
+  def validate_survey_condition
+    validate_unique_dependency unless duplicating?
+  end
+
+  def validate_unique_dependency
+    return unless required_surveys_for(conditional).include?(survey)
+    errors.add(:survey, :unique_dependency)
+  end
+
+  # Given a conditional object, returns all surveys that it requires.
+  #
+  # @param [#conditions] conditional The object that is declared as acts_as_conditional and for
+  #   which returned surveys are required.
+  # @return [Array<Course::Survey>]
+  def required_surveys_for(conditional)
+    # Course::Condition::Survey.
+    #   joins { condition.conditional(Course::Survey) }.
+    #   where.has { condition.conditional.id == survey.id }.
+    #   map(&:survey)
+
+    # Workaround, pending the squeel bugfix (activerecord-hackery/squeel#390) that will allow
+    # allow the above query to work without #reload
+    # TODO: use squeel
+    Course::Survey.joins(<<-SQL)
+      INNER JOIN
+        (SELECT cca.survey_id
+          FROM course_condition_surveys cca INNER JOIN course_conditions cc
+            ON cc.actable_type = 'Course::Condition::Survey' AND cc.actable_id = cca.id
+            WHERE cc.conditional_id = #{conditional.id}
+              AND cc.conditional_type = #{ActiveRecord::Base.connection.quote(conditional.class.name)}
+        ) ids
+      ON ids.survey_id = course_surveys.id
+    SQL
+  end
+end

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -20,7 +20,7 @@ class Course::Survey < ApplicationRecord
   has_many :sections, inverse_of: :survey, dependent: :destroy
   has_many :questions, through: :sections
   has_many :survey_conditions, class_name: Course::Condition::Survey.name,
-           inverse_of: :survey, dependent: :destroy
+                               inverse_of: :survey, dependent: :destroy
 
   # Used by the with_actable_types scope in Course::LessonPlan::Item.
   # Edit this to remove items for display.

--- a/app/models/course/survey.rb
+++ b/app/models/course/survey.rb
@@ -19,6 +19,8 @@ class Course::Survey < ApplicationRecord
                        class_name: Course::Survey::Response.name
   has_many :sections, inverse_of: :survey, dependent: :destroy
   has_many :questions, through: :sections
+  has_many :survey_conditions, class_name: Course::Condition::Survey.name,
+           inverse_of: :survey, dependent: :destroy
 
   # Used by the with_actable_types scope in Course::LessonPlan::Item.
   # Edit this to remove items for display.
@@ -44,6 +46,9 @@ class Course::Survey < ApplicationRecord
     self.course = duplicator.options[:destination_course]
     copy_attributes(other, duplicator)
     self.sections = duplicator.duplicate(other.sections)
+    survey_conditions << other.survey_conditions.
+                         select { |condition| duplicator.duplicated?(condition.conditional) }.
+                         map { |condition| duplicator.duplicate(condition) }
   end
 
   def include_in_consolidated_email?(event)

--- a/config/locales/en/activerecord/course/condition/survey.yml
+++ b/config/locales/en/activerecord/course/condition/survey.yml
@@ -1,0 +1,13 @@
+en:
+  activerecord:
+    models:
+      course/condition/survey: Survey Condition
+    attributes:
+      course/condition/survey/title:
+        complete: 'Complete %{survey_title}'
+    errors:
+      models:
+        course/condition/survey:
+          attributes:
+            survey:
+              unique_dependency: 'cannot have duplicate conditions'

--- a/config/locales/en/common.yml
+++ b/config/locales/en/common.yml
@@ -28,6 +28,9 @@ en:
       condition_assessment:
         create: 'Create Assessment Condition'
         update: 'Update Assessment Condition'
+      condition_survey:
+        create: 'Create Survey Condition'
+        update: 'Update Survey Condition'
     buttons:
       new: 'New %{model}'
       create: 'Create %{model}'

--- a/config/locales/en/course/condition/surveys.yml
+++ b/config/locales/en/course/condition/surveys.yml
@@ -1,8 +1,6 @@
 en:
   course:
     condition:
-      survey:
-        title: 'Survey'
       surveys:
         new:
           header: 'New Survey Condition'

--- a/config/locales/en/course/condition/surveys.yml
+++ b/config/locales/en/course/condition/surveys.yml
@@ -1,0 +1,17 @@
+en:
+  course:
+    condition:
+      survey:
+        title: 'Survey'
+      surveys:
+        new:
+          header: 'New Survey Condition'
+        create:
+          success: 'Survey condition was created.'
+        edit:
+          header: 'Edit Survey Condition'
+        update:
+          success: 'Survey condition was updated.'
+        destroy:
+          success: 'Survey condition was deleted.'
+          error: 'Failed to delete survey condition.'

--- a/db/migrate/20210821030941_create_course_condition_surveys.rb
+++ b/db/migrate/20210821030941_create_course_condition_surveys.rb
@@ -1,0 +1,8 @@
+class CreateCourseConditionSurveys < ActiveRecord::Migration[5.2]
+  def change
+    create_table :course_condition_surveys do |t|
+      t.references :survey, null: false, foreign_key: { to_table: :course_surveys },
+                            index: { name: 'fk__course_condition_surveys_survey_id' }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_074249) do
+ActiveRecord::Schema.define(version: 2021_08_21_030941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -449,6 +449,11 @@ ActiveRecord::Schema.define(version: 2021_01_12_074249) do
 
   create_table "course_condition_levels", force: :cascade do |t|
     t.integer "minimum_level", null: false
+  end
+
+  create_table "course_condition_surveys", force: :cascade do |t|
+    t.bigint "survey_id", null: false
+    t.index ["survey_id"], name: "fk__course_condition_surveys_survey_id"
   end
 
   create_table "course_conditions", force: :cascade do |t|
@@ -1255,6 +1260,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_074249) do
   add_foreign_key "course_assessments", "users", column: "updater_id", name: "fk_course_assessments_updater_id"
   add_foreign_key "course_condition_achievements", "course_achievements", column: "achievement_id", name: "fk_course_condition_achievements_achievement_id"
   add_foreign_key "course_condition_assessments", "course_assessments", column: "assessment_id", name: "fk_course_condition_assessments_assessment_id"
+  add_foreign_key "course_condition_surveys", "course_surveys", column: "survey_id"
   add_foreign_key "course_conditions", "courses", name: "fk_course_conditions_course_id"
   add_foreign_key "course_conditions", "users", column: "creator_id", name: "fk_course_conditions_creator_id"
   add_foreign_key "course_conditions", "users", column: "updater_id", name: "fk_course_conditions_updater_id"

--- a/spec/factories/course_condition_surveys.rb
+++ b/spec/factories/course_condition_surveys.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :course_condition_survey,
+          class: Course::Condition::Survey.name, aliases: [:survey_condition] do
+    course
+    survey
+    association :conditional, factory: :course_survey
+  end
+end

--- a/spec/models/course/condition/survey_spec.rb
+++ b/spec/models/course/condition/survey_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Course::Condition::Survey, type: :model do
+  it { is_expected.to act_as(Course::Condition) }
+
+  let!(:instance) { Instance.default }
+  with_tenant(:instance) do
+    let(:course) { create(:course) }
+
+    describe 'validations' do
+      subject do
+        survey = create(:survey, course: course)
+        build(:survey_condition,
+              course: course, survey: survey, conditional: survey)
+      end
+
+      context "when a survey is already included in its conditional's conditions" do
+        subject do
+          existing_survey_condition = create(:survey_condition, course: course)
+          build(:survey_condition,
+                course: course, conditional: existing_survey_condition.conditional,
+                survey: existing_survey_condition.survey)
+        end
+
+        it 'is not valid' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:survey]).to include(I18n.t('activerecord.errors.models.' \
+            'course/condition/survey.attributes.survey.unique_dependency'))
+        end
+      end
+    end
+
+    describe 'callbacks' do
+      let(:course) { create(:course) }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:survey) do
+        create(:survey, course: course, published: true,
+                        end_at: Time.zone.now + 1.day)
+      end
+
+      describe '#survey' do
+        context 'when the response is being submitted' do
+          let(:response_traits) { { submitted_at: Time.zone.now } }
+          it 'evaluate_conditional_for the affected course_user' do
+            expect(Course::Condition::Survey).
+              to receive(:evaluate_conditional_for).with(course_user)
+            create(:response, survey: survey, course_user: course_user,
+                              submitted_at: Time.zone.now, creator: course_user.user,
+                              updater: course_user.user)
+          end
+        end
+
+        context 'when the response is being unsubmitted' do
+          it 'evaluate_conditional_for the affected course_user' do
+            response = create(:response, survey: survey, course_user: course_user,
+                                         submitted_at: Time.zone.now,
+                                         creator: course_user.user,
+                                         updater: course_user.user)
+            expect(Course::Condition::Survey).
+              to receive(:evaluate_conditional_for).with(course_user)
+            response.unsubmit
+            response.save!
+          end
+        end
+      end
+    end
+
+    describe '#title' do
+      let(:survey) { create(:survey, course: course) }
+      subject { create(:course_condition_survey, survey: survey) }
+
+      it 'returns the correct survey title' do
+        expect(subject.title).
+          to eq(Course::Condition::Survey.human_attribute_name('title.complete', survey_title: survey.title))
+      end
+    end
+
+    describe '#satisfied_by?' do
+      let(:course) { create(:course) }
+      let(:course_user) { create(:course_student, course: course) }
+      let(:survey) do
+        create(:survey, course: course, published: true, end_at: Time.zone.now + 1.day)
+      end
+      subject { create(:course_condition_survey, survey: survey) }
+
+      context 'when there is no response' do
+        it 'returns false' do
+          expect(subject.satisfied_by?(course_user)).to be_falsey
+        end
+      end
+
+      context 'when the response is attempted' do
+        it 'returns false' do
+          create(:response, survey: survey, course_user: course_user,
+                            submitted_at: nil, creator: course_user.user,
+                            updater: course_user.user)
+          expect(subject.satisfied_by?(course_user)).to be_falsey
+        end
+      end
+
+      context 'when the response is submitted' do
+        it 'returns true' do
+          create(:response, survey: survey, course_user: course_user,
+                            submitted_at: Time.zone.now,
+                            creator: course_user.user, updater: course_user.user)
+          expect(subject.satisfied_by?(course_user)).to be_truthy
+        end
+      end
+    end
+
+    describe '#dependent_object' do
+      it 'returns the correct dependent survey object' do
+        expect(subject.dependent_object).to eq(subject.survey)
+      end
+    end
+
+    describe '.dependent_class' do
+      it 'returns Course::Survey' do
+        expect(Course::Condition::Survey.dependent_class).to eq(Course::Survey.name)
+      end
+    end
+  end
+end

--- a/spec/services/course/duplication/course_duplication_service_spec.rb
+++ b/spec/services/course/duplication/course_duplication_service_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
       end
 
       context 'when course has achievements' do
-        # Create 2 achievements. The first depends on the second achievement and a level.
+        # Create 2 achievements. The first depends on the second achievement, a level and a survey.
         let!(:achievements) { create_list(:course_achievement, 2, course: course) }
         let!(:achievement_with_badge) { create(:course_achievement, :with_badge, course: course) }
         let!(:achievement_condition) do
@@ -349,6 +349,10 @@ RSpec.describe Course::Duplication::CourseDuplicationService, type: :service do
         let!(:assessment_condition) do
           create(:course_condition_assessment, course: course, assessment: assessment,
                                                conditional: achievements[0])
+        end
+        let!(:survey_condition) do
+          create(:course_condition_survey, course: course, survey: survey,
+                                           conditional: achievements[0])
         end
 
         it 'duplicates achievements' do


### PR DESCRIPTION
Changes for this feature will be pushed as a stack of PRs, i.e. `master <- part-1 <- part-2 <- part-3`. You can find the other two PRs here:

- https://github.com/Coursemology/coursemology2/pull/4029
- https://github.com/zhuhanming/coursemology2/pull/2

The next PR will be rebased onto upstream master once this PR is merged.

## Summary

This summary covers the context for all 3 PRs, so it's a bit on the longer side.

### Context

We want to add a new type of condition - surveys, so that achievements can be given when students complete surveys.

Currently, Coursemology uses a condition-conditional framework.

- Conditionals are objects that can possess conditions, i.e. they will be "unlocked" upon having all their conditions met. There are two conditionals as of right now - achievements and assessments.
- Conditions are objects that represent some requirement to meet. This need not necessarily be an "object" like an assessment or achievement - it can be a level requirement as well, which has no `dependent_object`.

Thus, by adding a new survey condition, we can also make surveys a condition for assessments to unlock as well, not just for unlocking achievements.

### What is in this PR

This PR contains:

- DB migration - a new table, `course_condition_surveys`, is created to store the `id` of the condition `actable` and the `id` of the `survey` that it's depending on.
- Models - a new condition `actable` model and changes to the existing survey model (mostly an association + duplication logic of conditions that depend on it)
- Controllers - One main controller for the condition, and two for the two existing conditionals (achievement and assessment).
- Other assets, e.g. static YAML files that contain internationalised text.
- Test cases - mainly to test the modified models. The tests for the controllers are in the next PR, due to coupling between the controllers and the views (which have not been added yet).

## Test Plan

Run the test cases defined - there should be no failures or regression.

```bash
bundle exec rspec
```

Otherwise, the more visual/manual testing can only be done in the next PR, when the views have been added.